### PR TITLE
Extend 3Dcamera CameraInfo with rectification matrix

### DIFF
--- a/models/sensor/3dcamera/topics/cameraInfo.xml
+++ b/models/sensor/3dcamera/topics/cameraInfo.xml
@@ -20,6 +20,9 @@
     <property name="k" type="float64[9]" description="intrinsic camera matrix for the raw (distorted) images">
       <value></value>
     </property>
+    <property name="r" type="float64[9]" description="rectification matrix">
+      <value></value>
+    </property>
     <property name="p" type="float64[12]" description="by convention, this matrix specifies the intrinsic (camera) matrix of the processed (rectified) image">
       <value></value>
     </property>


### PR DESCRIPTION
Value used by stereo cameras. As per the explanation in [sensor_msgs/CameraInfo](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/CameraInfo.html) itself:

> A rotation matrix aligning the camera coordinate system to the ideal
> stereo image plane so that epipolar lines in both stereo images are
> parallel.