### PR TITLE
Change simulation-related interfaces in generic package to services

### DIFF
--- a/installator/hrim/scripts/classes.py
+++ b/installator/hrim/scripts/classes.py
@@ -41,6 +41,8 @@ class Topic:
         self.desc = None
         # the name of the artifact to be generated from the topic
         self.fileName = None
+        # the name of the interface's package of origin
+        self.package = None
     def addProp(self, property):
         self.properties.append(property)
     def addRes(self, response):

--- a/installator/hrim/scripts/compiling.py
+++ b/installator/hrim/scripts/compiling.py
@@ -192,7 +192,6 @@ class ModuleCompiler:
                 if topic.type == "service":
                     myDep = self.srvDeps
                     myFiles = srvFiles
-                    services = True
                     shortType = "srv"
                     if(self.base or module.type not in
                        ["actuator", "sensor", "communication",
@@ -202,12 +201,12 @@ class ModuleCompiler:
                         srvPkgName = "hrim_"+module.name+"_"+shortType+"s"
                     else:
                         srvPkgName = "hrim_"+module.type+"_"+module.name+"_"+shortType+"s"
+                    pkgName = srvPkgName
                     srvFolderPath = os.path.join(os.getcwd(), srvPkgName, shortType)
                     folderPath = srvFolderPath
                 if topic.type == "action":
                     myDep = self.actionDeps
                     myFiles = actionFiles
-                    actions = True
                     shortType = "action"
                     if(self.base or module.type not in
                        ["actuator", "sensor", "communication",
@@ -217,10 +216,13 @@ class ModuleCompiler:
                         actionPkgName = "hrim_"+module.name+"_"+shortType+"s"
                     else:
                         actionPkgName = "hrim_"+module.type+"_"+module.name+"_"+shortType+"s"
+                    pkgName = actionPkgName
                     actionFolderPath = os.path.join(os.getcwd(), actionPkgName, shortType)
                     folderPath = actionFolderPath
                 # check if file has already been generated
-                if topic.fileName not in myFiles:
+                if(topic.fileName not in myFiles
+                   and (topic.package is None or topic.package == pkgName)
+                  ):
 
                     # if the package directories don't exist, create them
                     if not os.path.exists(folderPath):
@@ -325,6 +327,11 @@ class ModuleCompiler:
                     textFile = open(fileName, "w")
                     textFile.write(fileContent)
                     textFile.close()
+
+                    if topic.type == "service":
+                        services = True
+                    if topic.type == "action":
+                        actions = True
 
         if self.msgPkgName in self.msgDeps:
             self.msgDeps.remove(self.msgPkgName)

--- a/installator/hrim/scripts/parsing.py
+++ b/installator/hrim/scripts/parsing.py
@@ -58,6 +58,8 @@ class ModuleParser:
         top = Topic(topic.attrib.get("name"), topic.attrib.get("type"), mandatory)
         if "description" in topic.attrib:
             top.desc = topic.attrib.get("description")
+        if "package" in topic.attrib:
+            top.package = topic.attrib.get("package")
         top.fileName = topic.attrib.get("fileName")
         for prop in topic:
             if prop.tag == "property":

--- a/models/generic/id.xml
+++ b/models/generic/id.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<topic name="id" type="publish" fileName="ID"
+<topic name="id" type="publish" fileName="ID" package="hrim_generic_msgs"
   xmlns:xi="http://www.w3.org/2001/XInclude">
   <property name="header" type="header" fileName="Header" package="std_msgs">
     <value></value>

--- a/models/generic/module_3d.xml
+++ b/models/generic/module_3d.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
-<topic name="module_3d" type="publish" fileName="Simulation3D"
+<topic name="module_3d" type="service" fileName="Simulation3D" package="hrim_generic_srvs"
   xmlns:xi="http://www.w3.org/2001/XInclude">
-  <property name="header" type="header" fileName="Header" package="std_msgs">
-    <value></value>
-  </property>
-  <property name="model_name" type="string" description="identifier name for the passed model">
-    <value></value>
-  </property>
-  <property name="model" type="byte[]" unit="stl" description=".stl of the component">
-    <value></value>
-  </property>
+  <response>
+    <property name="model_name" type="string" description="identifier name for the passed model">
+      <value></value>
+    </property>
+    <property name="model" type="byte[]" unit="stl" description=".stl of the component">
+      <value></value>
+    </property>
+  </response>
 </topic>

--- a/models/generic/module_urdf.xml
+++ b/models/generic/module_urdf.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0"?>
-<topic name="module_urdf" type="publish" fileName="SimulationURDF"
+<topic name="module_urdf" type="service" fileName="SimulationURDF" package="hrim_generic_srvs"
   xmlns:xi="http://www.w3.org/2001/XInclude">
-  <property name="header" type="header" fileName="Header" package="std_msgs">
-    <value></value>
-  </property>
-  <property name="urdf_model" type="string" unit="urdf" description="the urdf corresponding to the component's .stl">
-    <value></value>
-  </property>
+  <response>
+    <property name="urdf_model" type="string" unit="urdf" description="the urdf corresponding to the component's .stl">
+      <value></value>
+    </property>
+  </response>
 </topic>

--- a/models/generic/power.xml
+++ b/models/generic/power.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<topic name="power" type="publish" fileName="Power"
+<topic name="power" type="publish" fileName="Power" package="hrim_generic_msgs"
   xmlns:xi="http://www.w3.org/2001/XInclude">
   <property name="header" type="header" fileName="Header" package="std_msgs">
     <value></value>

--- a/models/generic/specs_comm.xml
+++ b/models/generic/specs_comm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<topic name="specs_comm" type="publish" fileName="SpecsCommunication"
+<topic name="specs_comm" type="publish" fileName="SpecsCommunication" package="hrim_generic_msgs"
   xmlns:xi="http://www.w3.org/2001/XInclude">
   <property name="header" type="header" fileName="Header" package="std_msgs">
     <value></value>

--- a/models/generic/state_comm.xml
+++ b/models/generic/state_comm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<topic name="state_comm" type="publish" fileName="StateCommunication"
+<topic name="state_comm" type="publish" fileName="StateCommunication" package="hrim_generic_msgs"
   xmlns:xi="http://www.w3.org/2001/XInclude">
   <property name="header" type="header" fileName="Header" package="std_msgs">
     <value></value>

--- a/models/generic/status.xml
+++ b/models/generic/status.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<topic name="status" type="publish" fileName="Status"
+<topic name="status" type="publish" fileName="Status" package="hrim_generic_msgs"
   xmlns:xi="http://www.w3.org/2001/XInclude">
   <property name="header" type="header" fileName="Header" package="std_msgs">
     <value></value>


### PR DESCRIPTION
Package of origin needs to be specified on the generic services to properly check for this dependency on all other packages, specified origin package on all generic interfaces.

