### PR TITLE
Add ROSIN acknowledgements

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,24 @@ While positioned at the repository's root all of the following are valid command
 * `hrim compose composite/arm sensor/imu actuator/gripper/gripper sensor/3dcamera/3dcamera_stereo`
 * `hrim compile model.xml`
 * `hrim compile validComposition.xml`
+
+
+***
+<!--
+    ROSIN acknowledgement from the ROSIN press kit
+    @ https://github.com/rosin-project/press_kit
+-->
+
+<a href="http://rosin-project.eu">
+  <img src="http://rosin-project.eu/wp-content/uploads/rosin_ack_logo_wide.png"
+       alt="rosin_logo" height="60" >
+</a></br>
+
+Supported by ROSIN - ROS-Industrial Quality-Assured Robot Software Components.
+More information: <a href="http://rosin-project.eu">rosin-project.eu</a>
+
+<img src="http://rosin-project.eu/wp-content/uploads/rosin_eu_flag.jpg"
+     alt="eu_flag" height="45" align="left" >
+
+This project has received funding from the European Union’s Horizon 2020
+research and innovation programme under grant agreement no. 732287.


### PR DESCRIPTION
As this project was partly funded by ROSIN, add ROSIN acknowledgements to the repository according to the [press kit information](https://github.com/rosin-project/press_kit#website-and-github-readme).